### PR TITLE
Add west.yml submanifest for test-sdk-nrf repositories

### DIFF
--- a/submanifests/99-default-test-nrf.yml
+++ b/submanifests/99-default-test-nrf.yml
@@ -1,0 +1,16 @@
+manifest:
+
+  remotes:
+    - name: ncs-test
+      url-base: https://projecttools.nordicsemi.no/bitbucket/scm/ncs-test
+
+
+  projects:
+    # NRF test repositories
+    - name: test_nrf
+      remote: ncs-test
+      repo-path: test-fw-nrfconnect-nrf
+      revision: master-prd
+      import:
+        path-prefix: test_nrf
+

--- a/west.yml
+++ b/west.yml
@@ -37,27 +37,17 @@ manifest:
       url-base: https://github.com/PelionIoT
     - name: memfault
       url-base: https://github.com/memfault
-    - name: ncs-test
-      url-base: https://projecttools.nordicsemi.no/bitbucket/scm/ncs-test
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
   defaults:
     remote: ncs
 
-  group-filter: [-homekit, -nrf-802154, -find-my, -test]
+  group-filter: [-homekit, -nrf-802154, -find-my]
 
   # "projects" is a list of git repositories which make up the NCS
   # source code.
   projects:
-
-    # NRF test repositories
-    - name: test_nrf
-      remote: ncs-test
-      repo-path: test-fw-nrfconnect-nrf
-      revision: master-prd
-      import:
-        path-prefix: test_nrf
 
     # The Zephyr RTOS fork in the NCS, along with the subset of its
     # modules which NCS imports directly.
@@ -199,3 +189,5 @@ manifest:
     # This line configures west extensions which are currently only
     # for internal use by NCS maintainers.
     west-commands: scripts/west-commands.yml
+
+    import: submanifests

--- a/west.yml
+++ b/west.yml
@@ -37,17 +37,27 @@ manifest:
       url-base: https://github.com/PelionIoT
     - name: memfault
       url-base: https://github.com/memfault
+    - name: ncs-test
+      url-base: https://projecttools.nordicsemi.no/bitbucket/scm/ncs-test
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
   defaults:
     remote: ncs
 
-  group-filter: [-homekit, -nrf-802154, -find-my]
+  group-filter: [-homekit, -nrf-802154, -find-my, -test]
 
   # "projects" is a list of git repositories which make up the NCS
   # source code.
   projects:
+
+    # NRF test repositories
+    - name: test_nrf
+      remote: ncs-test
+      repo-path: test-fw-nrfconnect-nrf
+      revision: master-prd
+      import:
+        path-prefix: test_nrf
 
     # The Zephyr RTOS fork in the NCS, along with the subset of its
     # modules which NCS imports directly.


### PR DESCRIPTION
This setup is used so the "99-default-test-nrf.yml" can be overwritten with e.g. a PR reference for the "revision:" instead of the default value.
This can be achieved with a file which starts with a lower number than the default e.g. "01-overwrite.yml".
The file needs to have the full manifest content like the default file.